### PR TITLE
Add native multi-repo content aggregation (sources:)

### DIFF
--- a/internal/aggregate/aggregate.go
+++ b/internal/aggregate/aggregate.go
@@ -1,0 +1,144 @@
+// Package aggregate implements multi-repo content fetching for mkdocs-server build.
+// It shallow-clones each source repo, copies its docs_dir content into a
+// temporary unified directory, and merges per-source nav trees.
+package aggregate
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/tcampbell/mkdocs-server/internal/config"
+)
+
+// Result holds the merged docs directory and nav produced by Aggregate.
+// Call Cleanup() when the build is done to remove the temporary directory.
+type Result struct {
+	DocsDir string
+	Nav     []config.NavItem
+	tempDir string
+}
+
+func (r *Result) Cleanup() {
+	if r.tempDir != "" {
+		os.RemoveAll(r.tempDir)
+	}
+}
+
+// Aggregate shallow-clones each source, copies its content into a shared
+// temporary directory, and merges nav entries.
+// Sources that fail to clone hard-fail the build.
+func Aggregate(sources []config.Source) (*Result, error) {
+	tempDir, err := os.MkdirTemp("", "mkdocs-server-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	docsDir := filepath.Join(tempDir, "docs")
+	var mergedNav []config.NavItem
+
+	for _, source := range sources {
+		fmt.Printf("fetching %s (%s @ %s)\n", source.Name, source.Repo, source.Ref)
+
+		repoDir := filepath.Join(tempDir, "repos", source.Name)
+		if err := clone(source, repoDir); err != nil {
+			os.RemoveAll(tempDir)
+			return nil, fmt.Errorf("clone source %q: %w", source.Name, err)
+		}
+
+		srcDocsDir := filepath.Join(repoDir, filepath.FromSlash(source.DocsDir))
+		dstDocsDir := filepath.Join(docsDir, source.Name)
+		if err := copyDir(srcDocsDir, dstDocsDir); err != nil {
+			os.RemoveAll(tempDir)
+			return nil, fmt.Errorf("copy docs for source %q: %w", source.Name, err)
+		}
+
+		children := sourceNav(source, repoDir)
+		mergedNav = append(mergedNav, config.NavItem{
+			Title:    source.Name,
+			Children: children,
+		})
+	}
+
+	return &Result{
+		DocsDir: docsDir,
+		Nav:     mergedNav,
+		tempDir: tempDir,
+	}, nil
+}
+
+// sourceNav reads the source repo's mkdocs.yml (searched adjacent to docs_dir)
+// and returns its nav items prefixed with the source name.
+func sourceNav(source config.Source, repoDir string) []config.NavItem {
+	docsAbs := filepath.Join(repoDir, filepath.FromSlash(source.DocsDir))
+	// mkdocs.yml conventionally lives one level above docs_dir
+	cfgPath := filepath.Join(filepath.Dir(docsAbs), "mkdocs.yml")
+
+	if _, err := os.Stat(cfgPath); err == nil {
+		if cfg, err := config.Load(cfgPath); err == nil && len(cfg.Nav) > 0 {
+			return prefixNav(cfg.Nav, source.Name+"/")
+		}
+	}
+	return nil
+}
+
+// prefixNav prepends prefix to every leaf path in a nav tree.
+func prefixNav(items []config.NavItem, prefix string) []config.NavItem {
+	result := make([]config.NavItem, len(items))
+	for i, item := range items {
+		result[i] = item
+		if item.Path != "" {
+			result[i].Path = prefix + item.Path
+		}
+		if len(item.Children) > 0 {
+			result[i].Children = prefixNav(item.Children, prefix)
+		}
+	}
+	return result
+}
+
+// clone shallow-clones a source repo at the given ref into destDir.
+func clone(source config.Source, destDir string) error {
+	if err := os.MkdirAll(filepath.Dir(destDir), 0o755); err != nil {
+		return err
+	}
+	cmd := exec.Command("git", "clone",
+		"--depth", "1",
+		"--branch", source.Ref,
+		"--", source.Repo, destDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		dstPath := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755)
+		}
+		return copyFile(path, dstPath)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/aggregate/aggregate.go
+++ b/internal/aggregate/aggregate.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/tcampbell/mkdocs-server/internal/config"
 )
@@ -32,6 +33,12 @@ func (r *Result) Cleanup() {
 // temporary directory, and merges nav entries.
 // Sources that fail to clone hard-fail the build.
 func Aggregate(sources []config.Source) (*Result, error) {
+	for _, s := range sources {
+		if err := validateSource(s); err != nil {
+			return nil, err
+		}
+	}
+
 	tempDir, err := os.MkdirTemp("", "mkdocs-server-*")
 	if err != nil {
 		return nil, fmt.Errorf("create temp dir: %w", err)
@@ -49,14 +56,18 @@ func Aggregate(sources []config.Source) (*Result, error) {
 			return nil, fmt.Errorf("clone source %q: %w", source.Name, err)
 		}
 
-		srcDocsDir := filepath.Join(repoDir, filepath.FromSlash(source.DocsDir))
+		docsPath := source.DocsDir
+		if docsPath == "" {
+			docsPath = "docs"
+		}
+		srcDocsDir := filepath.Join(repoDir, filepath.FromSlash(docsPath))
 		dstDocsDir := filepath.Join(docsDir, source.Name)
 		if err := copyDir(srcDocsDir, dstDocsDir); err != nil {
 			os.RemoveAll(tempDir)
 			return nil, fmt.Errorf("copy docs for source %q: %w", source.Name, err)
 		}
 
-		children := sourceNav(source, repoDir)
+		children := sourceNav(source, repoDir, docsPath)
 		mergedNav = append(mergedNav, config.NavItem{
 			Title:    source.Name,
 			Children: children,
@@ -70,15 +81,35 @@ func Aggregate(sources []config.Source) (*Result, error) {
 	}, nil
 }
 
+// validateSource rejects name values that would escape the temp directory
+// and repo URLs that use potentially dangerous schemes.
+func validateSource(s config.Source) error {
+	if strings.Contains(s.Name, "/") || strings.Contains(s.Name, "\\") || strings.Contains(s.Name, "..") {
+		return fmt.Errorf("source name %q must not contain path separators or ..", s.Name)
+	}
+	if s.Name == "" {
+		return fmt.Errorf("source name must not be empty")
+	}
+	if !strings.HasPrefix(s.Repo, "https://") && !strings.HasPrefix(s.Repo, "git@") && !strings.HasPrefix(s.Repo, "ssh://") {
+		return fmt.Errorf("source %q: repo URL must begin with https://, git@, or ssh://", s.Name)
+	}
+	return nil
+}
+
 // sourceNav reads the source repo's mkdocs.yml (searched adjacent to docs_dir)
 // and returns its nav items prefixed with the source name.
-func sourceNav(source config.Source, repoDir string) []config.NavItem {
-	docsAbs := filepath.Join(repoDir, filepath.FromSlash(source.DocsDir))
+func sourceNav(source config.Source, repoDir, docsPath string) []config.NavItem {
+	docsAbs := filepath.Join(repoDir, filepath.FromSlash(docsPath))
 	// mkdocs.yml conventionally lives one level above docs_dir
 	cfgPath := filepath.Join(filepath.Dir(docsAbs), "mkdocs.yml")
 
 	if _, err := os.Stat(cfgPath); err == nil {
-		if cfg, err := config.Load(cfgPath); err == nil && len(cfg.Nav) > 0 {
+		cfg, err := config.Load(cfgPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: cannot read nav from %s: %v\n", cfgPath, err)
+			return nil
+		}
+		if len(cfg.Nav) > 0 {
 			return prefixNav(cfg.Nav, source.Name+"/")
 		}
 	}
@@ -87,6 +118,9 @@ func sourceNav(source config.Source, repoDir string) []config.NavItem {
 
 // prefixNav prepends prefix to every leaf path in a nav tree.
 func prefixNav(items []config.NavItem, prefix string) []config.NavItem {
+	if len(items) == 0 {
+		return nil
+	}
 	result := make([]config.NavItem, len(items))
 	for i, item := range items {
 		result[i] = item
@@ -138,7 +172,9 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-	_, err = io.Copy(out, in)
-	return err
+	defer func() { out.Close() }()
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
 }

--- a/internal/aggregate/aggregate.go
+++ b/internal/aggregate/aggregate.go
@@ -10,9 +10,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/tcampbell/mkdocs-server/internal/config"
+)
+
+var (
+	validName = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	validRef  = regexp.MustCompile(`^[A-Za-z0-9_./-]+$`)
 )
 
 // Result holds the merged docs directory and nav produced by Aggregate.
@@ -81,17 +87,23 @@ func Aggregate(sources []config.Source) (*Result, error) {
 	}, nil
 }
 
-// validateSource rejects name values that would escape the temp directory
-// and repo URLs that use potentially dangerous schemes.
+// validateSource rejects names or refs that could cause path traversal or
+// flag injection, and limits repo URLs to known safe schemes.
 func validateSource(s config.Source) error {
-	if strings.Contains(s.Name, "/") || strings.Contains(s.Name, "\\") || strings.Contains(s.Name, "..") {
-		return fmt.Errorf("source name %q must not contain path separators or ..", s.Name)
-	}
 	if s.Name == "" {
 		return fmt.Errorf("source name must not be empty")
 	}
+	if !validName.MatchString(s.Name) {
+		return fmt.Errorf("source name %q must contain only letters, digits, hyphens, and underscores", s.Name)
+	}
 	if !strings.HasPrefix(s.Repo, "https://") && !strings.HasPrefix(s.Repo, "git@") && !strings.HasPrefix(s.Repo, "ssh://") {
 		return fmt.Errorf("source %q: repo URL must begin with https://, git@, or ssh://", s.Name)
+	}
+	if s.Ref == "" {
+		return fmt.Errorf("source %q: ref must not be empty", s.Name)
+	}
+	if !validRef.MatchString(s.Ref) {
+		return fmt.Errorf("source %q: ref %q contains invalid characters", s.Name, s.Ref)
 	}
 	return nil
 }
@@ -153,6 +165,10 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
+		// Skip symlinks — a symlink in a cloned repo could point outside the repo tree.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
 		rel, _ := filepath.Rel(src, path)
 		dstPath := filepath.Join(dst, rel)
 		if d.IsDir() {
@@ -172,9 +188,13 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer func() { out.Close() }()
 	if _, err = io.Copy(out, in); err != nil {
+		out.Close()
 		return err
 	}
-	return out.Sync()
+	if err = out.Sync(); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/internal/aggregate/aggregate.go
+++ b/internal/aggregate/aggregate.go
@@ -67,6 +67,12 @@ func Aggregate(sources []config.Source) (*Result, error) {
 			docsPath = "docs"
 		}
 		srcDocsDir := filepath.Join(repoDir, filepath.FromSlash(docsPath))
+		// Ensure docs_dir cannot escape the clone root via .. segments.
+		repoBound := repoDir + string(filepath.Separator)
+		if srcDocsDir != repoDir && !strings.HasPrefix(srcDocsDir+string(filepath.Separator), repoBound) {
+			os.RemoveAll(tempDir)
+			return nil, fmt.Errorf("source %q: docs_dir %q escapes repo root", source.Name, docsPath)
+		}
 		dstDocsDir := filepath.Join(docsDir, source.Name)
 		if err := copyDir(srcDocsDir, dstDocsDir); err != nil {
 			os.RemoveAll(tempDir)
@@ -110,19 +116,21 @@ func validateSource(s config.Source) error {
 
 // sourceNav reads the source repo's mkdocs.yml (searched adjacent to docs_dir)
 // and returns its nav items prefixed with the source name.
+// Uses LoadNavOnly so INHERIT directives in the source config are not followed —
+// a malicious source cannot use INHERIT to read host files outside the clone.
 func sourceNav(source config.Source, repoDir, docsPath string) []config.NavItem {
 	docsAbs := filepath.Join(repoDir, filepath.FromSlash(docsPath))
 	// mkdocs.yml conventionally lives one level above docs_dir
 	cfgPath := filepath.Join(filepath.Dir(docsAbs), "mkdocs.yml")
 
 	if _, err := os.Stat(cfgPath); err == nil {
-		cfg, err := config.Load(cfgPath)
+		nav, err := config.LoadNavOnly(cfgPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: cannot read nav from %s: %v\n", cfgPath, err)
 			return nil
 		}
-		if len(cfg.Nav) > 0 {
-			return prefixNav(cfg.Nav, source.Name+"/")
+		if len(nav) > 0 {
+			return prefixNav(nav, source.Name+"/")
 		}
 	}
 	return nil

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tcampbell/mkdocs-server/internal/aggregate"
 	"github.com/tcampbell/mkdocs-server/internal/assets"
 	"github.com/tcampbell/mkdocs-server/internal/config"
 )
@@ -23,6 +24,21 @@ func Build(configPath string) error {
 	// Resolve docs and site dirs relative to the config file location.
 	docsDir := filepath.Join(cfg.ConfigDir, cfg.DocsDir)
 	siteDir := filepath.Join(cfg.ConfigDir, cfg.SiteDir)
+
+	// Multi-repo aggregation: when sources are defined, clone each source repo
+	// and assemble a unified docs directory. The normal build pipeline then runs
+	// against that directory using the merged nav.
+	if len(cfg.Sources) > 0 {
+		result, err := aggregate.Aggregate(cfg.Sources)
+		if err != nil {
+			return err
+		}
+		defer result.Cleanup()
+		docsDir = result.DocsDir
+		if len(cfg.Nav) == 0 {
+			cfg.Nav = result.Nav
+		}
+	}
 
 	if err := os.MkdirAll(siteDir, 0o755); err != nil {
 		return fmt.Errorf("create site dir: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Source defines a remote git repo whose content is aggregated into the build.
+type Source struct {
+	Name    string `yaml:"name"`    // namespace prefix in the merged docs tree
+	Repo    string `yaml:"repo"`    // remote URL, e.g. https://github.com/org/repo
+	Ref     string `yaml:"ref"`     // branch, tag, or commit-ish
+	DocsDir string `yaml:"docs_dir"` // path within the repo to the markdown content
+}
+
 type Config struct {
 	SiteName  string `yaml:"site_name"`
 	SiteURL   string `yaml:"site_url"`
@@ -20,6 +28,7 @@ type Config struct {
 	ExtraCSS []string  `yaml:"extra_css"`
 	Nav      []NavItem `yaml:"-"`
 	Inherit  string    `yaml:"INHERIT"`
+	Sources  []Source  `yaml:"sources"`
 
 	// directory containing the config file — used to resolve relative paths
 	ConfigDir string `yaml:"-"`
@@ -44,6 +53,7 @@ type rawConfig struct {
 	ExtraCSS []string `yaml:"extra_css"`
 	Nav      []any    `yaml:"nav"`
 	Inherit  string   `yaml:"INHERIT"`
+	Sources  []Source `yaml:"sources"`
 }
 
 func Load(configPath string) (*Config, error) {
@@ -77,6 +87,7 @@ func load(absPath string, seen map[string]bool) (*Config, error) {
 		SiteDir:   raw.SiteDir,
 		ExtraCSS:  raw.ExtraCSS,
 		Inherit:   raw.Inherit,
+		Sources:   raw.Sources,
 		ConfigDir: filepath.Dir(absPath),
 	}
 	cfg.Theme.Name = raw.Theme.Name

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,20 @@ func Load(configPath string) (*Config, error) {
 	return load(abs, map[string]bool{})
 }
 
+// LoadNavOnly parses only the nav from configPath without following INHERIT.
+// It is safe to call on untrusted configs (e.g. from cloned source repos).
+func LoadNavOnly(configPath string) ([]NavItem, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read config %s: %w", configPath, err)
+	}
+	var raw rawConfig
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", configPath, err)
+	}
+	return parseNav(raw.Nav), nil
+}
+
 func load(absPath string, seen map[string]bool) (*Config, error) {
 	if seen[absPath] {
 		return nil, fmt.Errorf("INHERIT cycle detected: %s", absPath)


### PR DESCRIPTION
## Summary

- Adds a `sources:` key to `mkdocs.yml` enabling aggregator repos with no local content
- Each source is shallow-cloned at a pinnable `ref:`, its `docs_dir` mounted under a `name:` namespace, and its nav merged as a top-level section
- Single-repo builds are completely unaffected (no `sources:` → no change)
- Hard-fails on unreachable source (safe default); no caching (re-clone on every build, simplest)

## Test plan

- [x] Smoke test: aggregator config pointing at `tcampbell/okr-doctor@main` — cloned, built 8 pages namespaced under `/okr-doctor/`, search index correct
- [x] Single-repo build (okr-doctor normal `make dist`) still works — no regression
- [ ] Two-source aggregator (requires a second public repo with docs)

Closes tcampbell/okr-doctor#17
