### PR TITLE
Position search reset button via overrides stylesheet

### DIFF
--- a/internal/assets/stylesheets/overrides.min.css
+++ b/internal/assets/stylesheets/overrides.min.css
@@ -1,0 +1,1 @@
+.md-search__icon[type=reset]{position:absolute;top:.6rem;right:.8rem;z-index:2;transform:scale(.125);opacity:0;transition:transform .15s cubic-bezier(.1,.7,.1,1),opacity .15s}.md-search__form>.md-search__input:valid~.md-search__icon[type=reset]{transform:scale(1);opacity:1;pointer-events:initial}

--- a/internal/build/tmpl/page.html
+++ b/internal/build/tmpl/page.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="{{.Base}}/_assets/images/favicon.png" />
     <link rel="stylesheet" href="{{.Base}}/_assets/stylesheets/main.min.css" />
     <link rel="stylesheet" href="{{.Base}}/_assets/stylesheets/palette.min.css" />
+    <link rel="stylesheet" href="{{.Base}}/_assets/stylesheets/overrides.min.css" />
     {{range .ExtraCSS}}<link rel="stylesheet" href="{{.}}" />
     {{end}}</head>
   <body


### PR DESCRIPTION
## Summary

- The Material 9.7.6 CSS extracted into `main.min.css` is missing the
  rules that absolute-position the search reset button. Without them the
  X button renders as a block element below the input rather than inside
  it on the right.
- Adds `internal/assets/stylesheets/overrides.min.css` with two rules:
  one that absolute-positions `.md-search__icon[type=reset]` (hidden by
  default), one that reveals it once `.md-search__input:valid` is true.
  `[type=reset]` cleanly distinguishes the button from the magnifier
  label without touching existing `[for=__search]` rules.
- Links the new stylesheet from `page.html` after the upstream sheets so
  any future override rules can land in the same file.
- Picked up automatically by the existing
  `//go:embed stylesheets javascripts images` in
  `internal/assets/assets.go`; `copyAssets` walks the embed FS so no
  copy logic changes are required.

## Test plan

- [x] `go build ./...` passes
- [x] Built a minimal test site with the new binary; `site/index.html`
      links `overrides.min.css` and the file is present in
      `site/_assets/stylesheets/`
- [ ] Visual confirmation on a Material-themed page: X reset button
      appears inside the search input on the right and animates in once
      the user types
- [ ] Cross-browser sanity check (latest Chrome, Safari, Firefox)
