### PR TITLE
Apply gofmt to template.go and config.go

### DIFF
--- a/internal/build/template.go
+++ b/internal/build/template.go
@@ -19,7 +19,7 @@ var pageTmpl = template.Must(
 type pageData struct {
 	SiteName   string
 	PageTitle  string
-	Base       string        // relative path from this page to site root (e.g. "." or "..")
+	Base       string // relative path from this page to site root (e.g. "." or "..")
 	Content    template.HTML
 	Nav        template.HTML
 	ExtraCSS   []string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,18 +10,18 @@ import (
 
 // Source defines a remote git repo whose content is aggregated into the build.
 type Source struct {
-	Name    string `yaml:"name"`    // namespace prefix in the merged docs tree
-	Repo    string `yaml:"repo"`    // remote URL, e.g. https://github.com/org/repo
-	Ref     string `yaml:"ref"`     // branch, tag, or commit-ish
+	Name    string `yaml:"name"`     // namespace prefix in the merged docs tree
+	Repo    string `yaml:"repo"`     // remote URL, e.g. https://github.com/org/repo
+	Ref     string `yaml:"ref"`      // branch, tag, or commit-ish
 	DocsDir string `yaml:"docs_dir"` // path within the repo to the markdown content
 }
 
 type Config struct {
-	SiteName  string `yaml:"site_name"`
-	SiteURL   string `yaml:"site_url"`
-	DocsDir   string `yaml:"docs_dir"`
-	SiteDir   string `yaml:"site_dir"`
-	Theme     struct {
+	SiteName string `yaml:"site_name"`
+	SiteURL  string `yaml:"site_url"`
+	DocsDir  string `yaml:"docs_dir"`
+	SiteDir  string `yaml:"site_dir"`
+	Theme    struct {
 		Name     string   `yaml:"name"`
 		Features []string `yaml:"features"`
 	} `yaml:"theme"`


### PR DESCRIPTION
Apply gofmt to template.go and config.go

Pre-existing struct-tag alignment drift surfaced by `gofmt -l .` while
running CI hygiene checks for the new golden-test PR (#5).
Pure formatting; no behavior change.

Clears the way for the lint step landing under #3.
